### PR TITLE
Add baseurl to post navigation & avatar image url

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
 		</a>
 		{% elsif site.theme.avatar %}
 		<a href="{{ site.baseurl }}/">
-			<img class="avatar" src="/img/{{ site.theme.avatar }}" alt=""/>
+			<img class="avatar" src="{{ site.baseurl }}/img/{{ site.theme.avatar }}" alt=""/>
 		</a>
 		{% endif %}
 		<h1 class="site-title">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,13 +16,13 @@ layout: default
 {% if site.theme.post_navigation %}
 <div id="post-nav">
     {% if page.previous.url %}
-    <a id="prev-post" href="{{ page.previous.url }}">
+    <a id="prev-post" href="{{ site.baseurl }}{{ page.previous.url }}">
       <span class="page-title">{{ page.previous.title }}</span>
       <i class="fa fa-chevron-left"></i> {{ site.theme.str_prev }}
     </a>
     {% endif %}
     {% if page.next.url %}
-    <a id="next-post" href="{{ page.next.url }}">
+    <a id="next-post" href="{{ site.baseurl }}{{ page.next.url }}">
       <span class="page-title">{{ page.next.title }}</span>
        {{ site.theme.str_next }} <i class="fa fa-chevron-right"></i>
      </a>


### PR DESCRIPTION
Fix the post navigation bad url

When try to use post navigation and the site baseurl have any value on it like "/blog" then site load on this subpath but the post navigation url doesn't add it to the next or prev url

Fix the same problem with avatar image src
