### PR TITLE
fix support for jekyll 3.2.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ baseurl: "" # the subpath of your site, e.g. /blog/
 url: "http://example.com" # the base hostname & protocol for your site
 
 # THEME-SPECIFIC CONFIGURATION
-theme:
+theme_settings:
   # Meta
   title: Type Theme
   avatar: avatar.png

--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -1,6 +1,6 @@
 <div id="disqus_thread"></div>
 <script type="text/javascript">
-	var disqus_shortname = '{{ site.theme.disqus_shortname }}';
+	var disqus_shortname = '{{ site.theme_settings.disqus_shortname }}';
 	(function() {
 		var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
 		dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,9 +1,9 @@
-{% if site.theme.katex %}
+{% if site.theme_settings.katex %}
 <script src="{{ "/js/katex_init.js" | prepend: site.baseurl }}"></script>
 {% endif %}
 
-{% if site.theme.footer_text %}
+{% if site.theme_settings.footer_text %}
 <footer class="site-footer">
-	<p class="text">{{ site.theme.footer_text }}</p>
+	<p class="text">{{ site.theme_settings.footer_text }}</p>
 </footer>
 {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,7 @@
 <head>
 	<meta charset="utf-8">
-	<title>{% if page.title %}{{ page.title }} |{% endif %} {{ site.theme.title }}</title>
-	<meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.theme.description }}{% endif %}">
+	<title>{% if page.title %}{{ page.title }} |{% endif %} {{ site.theme_settings.title }}</title>
+	<meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.theme_settings.description }}{% endif %}">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta http-equiv="X-Frame-Options" content="sameorigin">
 
@@ -15,31 +15,31 @@
 	<link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 
 	<!-- RSS -->
-	<link rel="alternate" type="application/atom+xml" title="{{ site.theme.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
+	<link rel="alternate" type="application/atom+xml" title="{{ site.theme_settings.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
 
 	<!-- Font Awesome -->
 	<link href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet">
 
 	<!-- Google Fonts -->
-	{% if site.theme.google_fonts %}
-	<link href="//fonts.googleapis.com/css?family={{ site.theme.google_fonts }}" rel="stylesheet" type="text/css">
+	{% if site.theme_settings.google_fonts %}
+	<link href="//fonts.googleapis.com/css?family={{ site.theme_settings.google_fonts }}" rel="stylesheet" type="text/css">
 	{% endif %}
 
 	<!-- KaTeX -->
-	{% if site.theme.katex %}
+	{% if site.theme_settings.katex %}
 	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.3.0/katex.min.css">
 	<script src="//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.3.0/katex.min.js"></script>
 	{% endif %}
 
 	<!-- Google Analytics -->
-	{% if site.theme.google_analytics %}
+	{% if site.theme_settings.google_analytics %}
 	<script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
 	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 	})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-	ga('create', '{{ site.theme.google_analytics }}', 'auto');
+	ga('create', '{{ site.theme_settings.google_analytics }}', 'auto');
 	ga('send', 'pageview');
 	</script>
 	{% endif %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,16 +1,16 @@
 <header class="site-header">
 	<div class="branding">
-		{% if site.theme.gravatar %}
+		{% if site.theme_settings.gravatar %}
 		<a href="{{ site.baseurl }}/">
-			<img class="avatar" src="https://secure.gravatar.com/avatar/{{ site.theme.gravatar }}?s=100" alt=""/>
+			<img class="avatar" src="https://secure.gravatar.com/avatar/{{ site.theme_settings.gravatar }}?s=100" alt=""/>
 		</a>
-		{% elsif site.theme.avatar %}
+		{% elsif site.theme_settings.avatar %}
 		<a href="{{ site.baseurl }}/">
-			<img class="avatar" src="{{ site.baseurl }}/img/{{ site.theme.avatar }}" alt=""/>
+			<img class="avatar" src="{{ site.baseurl }}/img/{{ site.theme_settings.avatar }}" alt=""/>
 		</a>
 		{% endif %}
 		<h1 class="site-title">
-			<a href="{{ site.baseurl }}/">{{ site.theme.title }}</a>
+			<a href="{{ site.baseurl }}/">{{ site.theme_settings.title }}</a>
 		</h1>
 	</div>
 	<nav class="site-nav">

--- a/_includes/icons.html
+++ b/_includes/icons.html
@@ -1,158 +1,158 @@
-{% if site.theme.rss %}
+{% if site.theme_settings.rss %}
 <li>
-	<a href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" title="{{ site.theme.str_rss_follow }}">
+	<a href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" title="{{ site.theme_settings.str_rss_follow }}">
 		<i class="fa fa-fw fa-rss"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.email_address %}
+{% if site.theme_settings.email_address %}
 <li>
-	<a href="mailto:{{ site.theme.email_address }}" title="{{ site.theme.str_email }}">
+	<a href="mailto:{{ site.theme_settings.email_address }}" title="{{ site.theme_settings.str_email }}">
 		<i class="fa fa-fw fa-envelope"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.behance %}
+{% if site.theme_settings.behance %}
 <li>
-	<a href="https://www.behance.net/{{ site.theme.behance }}" title="{{ site.theme.str_follow_on }} Behance">
+	<a href="https://www.behance.net/{{ site.theme_settings.behance }}" title="{{ site.theme_settings.str_follow_on }} Behance">
 		<i class="fa fa-fw fa-behance"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.bitbucket %}
+{% if site.theme_settings.bitbucket %}
 <li>
-	<a href="https://bitbucket.org/{{ site.theme.bitbucket }}" title="{{ site.theme.str_follow_on }} Bitbucket">
+	<a href="https://bitbucket.org/{{ site.theme_settings.bitbucket }}" title="{{ site.theme_settings.str_follow_on }} Bitbucket">
 		<i class="fa fa-fw fa-bitbucket"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.dribbble %}
+{% if site.theme_settings.dribbble %}
 <li>
-	<a href="https://dribbble.com/{{ site.theme.dribbble }}" title="{{ site.theme.str_follow_on }} Dribbble">
+	<a href="https://dribbble.com/{{ site.theme_settings.dribbble }}" title="{{ site.theme_settings.str_follow_on }} Dribbble">
 		<i class="fa fa-fw fa-dribbble"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.facebook %}
+{% if site.theme_settings.facebook %}
 <li>
-	<a href="https://www.facebook.com/{{ site.theme.facebook }}" title="{{ site.theme.str_follow_on }} Facebook">
+	<a href="https://www.facebook.com/{{ site.theme_settings.facebook }}" title="{{ site.theme_settings.str_follow_on }} Facebook">
 		<i class="fa fa-fw fa-facebook"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.flickr %}
+{% if site.theme_settings.flickr %}
 <li>
-	<a href="https://www.flickr.com/photos/{{ site.theme.flickr }}" title="{{ site.theme.str_follow_on }} Flickr">
+	<a href="https://www.flickr.com/photos/{{ site.theme_settings.flickr }}" title="{{ site.theme_settings.str_follow_on }} Flickr">
 		<i class="fa fa-fw fa-flickr"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.github %}
+{% if site.theme_settings.github %}
 <li>
-	<a href="https://github.com/{{ site.theme.github }}" title="{{ site.theme.str_follow_on }} GitHub">
+	<a href="https://github.com/{{ site.theme_settings.github }}" title="{{ site.theme_settings.str_follow_on }} GitHub">
 		<i class="fa fa-fw fa-github"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.google_plus %}
+{% if site.theme_settings.google_plus %}
 <li>
-	<a href="https://plus.google.com/{{ site.theme.google_plus }}" title="{{ site.theme.str_follow_on }} Google+">
+	<a href="https://plus.google.com/{{ site.theme_settings.google_plus }}" title="{{ site.theme_settings.str_follow_on }} Google+">
 		<i class="fa fa-fw fa-google-plus"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.instagram %}
+{% if site.theme_settings.instagram %}
 <li>
-	<a href="http://instagram.com/{{ site.theme.instagram }}" title="{{ site.theme.str_follow_on }} Instagram">
+	<a href="http://instagram.com/{{ site.theme_settings.instagram }}" title="{{ site.theme_settings.str_follow_on }} Instagram">
 		<i class="fa fa-fw fa-instagram"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.linkedin %}
+{% if site.theme_settings.linkedin %}
 <li>
-	<a href="{{ site.theme.linkedin }}" title="{{ site.theme.str_follow_on }} LinkedIn">
+	<a href="{{ site.theme_settings.linkedin }}" title="{{ site.theme_settings.str_follow_on }} LinkedIn">
 		<i class="fa fa-fw fa-linkedin"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.pinterest %}
+{% if site.theme_settings.pinterest %}
 <li>
-	<a href="http://www.pinterest.com/{{ site.theme.pinterest }}" title="{{ site.theme.str_follow_on }} Pinterest">
+	<a href="http://www.pinterest.com/{{ site.theme_settings.pinterest }}" title="{{ site.theme_settings.str_follow_on }} Pinterest">
 		<i class="fa fa-fw fa-pinterest"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.reddit %}
+{% if site.theme_settings.reddit %}
 <li>
-	<a href="https://www.reddit.com/user/{{ site.theme.reddit }}" title="{{ site.theme.str_follow_on }} Reddit">
+	<a href="https://www.reddit.com/user/{{ site.theme_settings.reddit }}" title="{{ site.theme_settings.str_follow_on }} Reddit">
 		<i class="fa fa-fw fa-reddit"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.soundcloud %}
+{% if site.theme_settings.soundcloud %}
 <li>
-	<a href="https://soundcloud.com/{{ site.theme.soundcloud }}" title="{{ site.theme.str_follow_on }} SoundCloud">
+	<a href="https://soundcloud.com/{{ site.theme_settings.soundcloud }}" title="{{ site.theme_settings.str_follow_on }} SoundCloud">
 		<i class="fa fa-fw fa-soundcloud"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.stack_exchange %}
+{% if site.theme_settings.stack_exchange %}
 <li>
-	<a href="{{ site.theme.stack_exchange }}" title="{{ site.theme.str_follow_on }} Stack Exchange">
+	<a href="{{ site.theme_settings.stack_exchange }}" title="{{ site.theme_settings.str_follow_on }} Stack Exchange">
 		<i class="fa fa-fw fa-stack-exchange"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.steam %}
+{% if site.theme_settings.steam %}
 <li>
-	<a href="http://steamcommunity.com/id/{{ site.theme.steam }}" title="{{ site.theme.str_follow_on }} Steam">
+	<a href="http://steamcommunity.com/id/{{ site.theme_settings.steam }}" title="{{ site.theme_settings.str_follow_on }} Steam">
 		<i class="fa fa-fw fa-steam"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.tumblr %}
+{% if site.theme_settings.tumblr %}
 <li>
-	<a href="http://{{ site.theme.tumblr }}.tumblr.com/" title="{{ site.theme.str_follow_on }} Tumblr">
+	<a href="http://{{ site.theme_settings.tumblr }}.tumblr.com/" title="{{ site.theme_settings.str_follow_on }} Tumblr">
 		<i class="fa fa-fw fa-tumblr"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.twitter %}
+{% if site.theme_settings.twitter %}
 <li>
-	<a href="https://twitter.com/{{ site.theme.twitter }}" title="{{ site.theme.str_follow_on }} Twitter">
+	<a href="https://twitter.com/{{ site.theme_settings.twitter }}" title="{{ site.theme_settings.str_follow_on }} Twitter">
 		<i class="fa fa-fw fa-twitter"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.wordpress %}
+{% if site.theme_settings.wordpress %}
 <li>
-	<a href="https://{{ site.theme.wordpress }}.wordpress.com/" title="{{ site.theme.str_follow_on }} WordPress">
+	<a href="https://{{ site.theme_settings.wordpress }}.wordpress.com/" title="{{ site.theme_settings.str_follow_on }} WordPress">
 		<i class="fa fa-fw fa-wordpress"></i>
 	</a>
 </li>
 {% endif %}
 
-{% if site.theme.youtube %}
+{% if site.theme_settings.youtube %}
 <li>
-	<a href="https://www.youtube.com/user/{{ site.theme.youtube }}" title="{{ site.theme.str_follow_on }} YouTube">
+	<a href="https://www.youtube.com/user/{{ site.theme_settings.youtube }}" title="{{ site.theme_settings.str_follow_on }} YouTube">
 		<i class="fa fa-fw fa-youtube"></i>
 	</a>
 </li>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,13 +13,13 @@ layout: default
 </article>
 
 <!-- Post navigation -->
-{% if site.theme.post_navigation %}
+{% if site.theme_settings.post_navigation %}
 <div id="post-nav">
     {% if page.previous.url %}
     <a id="prev-post" href="{{ site.baseurl }}{{ page.previous.url }}">
       <span class="page-title">{{ page.previous.title }}</span>
       <span class="nav-label">
-        <i class="fa fa-chevron-left"></i> {{ site.theme.str_prev }}
+        <i class="fa fa-chevron-left"></i> {{ site.theme_settings.str_prev }}
       </span>
     </a>
     {% endif %}
@@ -27,7 +27,7 @@ layout: default
     <a id="next-post" href="{{ site.baseurl }}{{ page.next.url }}">
        <span class="page-title">{{ page.next.title }}</span>
        <span class="nav-label">
-        {{ site.theme.str_next }} <i class="fa fa-chevron-right"></i>
+        {{ site.theme_settings.str_next }} <i class="fa fa-chevron-right"></i>
        </span>
      </a>
     {% endif %}
@@ -35,7 +35,7 @@ layout: default
 {% endif %}
 
 <!-- Disqus -->
-{% if site.theme.disqus_shortname %}
+{% if site.theme_settings.disqus_shortname %}
 <div class="comments">
   {% include disqus.html %}
 </div>

--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@ layout: default
 ---
 
 <div class="home">
-  {% if site.theme.header_text %}
-  <div class="call-out" 
-  style="background-image: url('{{ site.baseurl }}/{{ site.theme.header_text_feature_image }}')">
-    {{ site.theme.header_text }}
+  {% if site.theme_settings.header_text %}
+  <div class="call-out"
+  style="background-image: url('{{ site.baseurl }}/{{ site.theme_settings.header_text_feature_image }}')">
+    {{ site.theme_settings.header_text }}
   </div>
   {% endif %}
 
@@ -26,7 +26,7 @@ layout: default
       <div class="excerpt">
         {{ post.excerpt }}
         <a class="button" href="{{ post.url | prepend: site.baseurl }}">
-          {{ site.theme.str_continue_reading }}
+          {{ site.theme_settings.str_continue_reading }}
         </a>
       </div>
     </div>
@@ -38,12 +38,12 @@ layout: default
     {% if paginator.previous_page %}
     <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="button" >
       <i class="fa fa-chevron-left"></i>
-      {{ site.theme.str_prev }}
+      {{ site.theme_settings.str_prev }}
     </a>
     {% endif %}
     {% if paginator.next_page %}
     <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="button" >
-      {{ site.theme.str_next }}
+      {{ site.theme_settings.str_next }}
       <i class="fa fa-chevron-right"></i>
     </a>
     {% endif %}


### PR DESCRIPTION
Following https://github.com/jekyll/jekyll/issues/5163, the theme errors when building, raising an undefined downcase method. This is because in 3.2.0, `theme` is a key reserved for a gem-based theme for Jekyll.

I renamed `theme` to `theme_settings` and replaced all of its uses in the files. Feedback appreciated.
