### PR TITLE
Add support for Muut commenting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,6 +44,7 @@ theme_settings:
   # Scripts
   google_analytics: # Tracking ID, e.g. "UA-000000-01"
   disqus_shortname:
+  muut_community_name: # From muut.com settings, e.g. "muttcommunityname"
   katex: true # Enable if using math markup
 
   # Localization strings

--- a/_includes/muut.html
+++ b/_includes/muut.html
@@ -1,0 +1,3 @@
+<!-- _includes/muut.html -->
+<a class="muut" href="https://muut.com/i/{{site.theme_settings.muut_community_name}}/comments" type="dynamic">{{site.theme_settings.muut_community_name}}</a>
+<script async src="//cdn.muut.com/1/moot.min.js"></script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -40,3 +40,10 @@ layout: default
   {% include disqus.html %}
 </div>
 {% endif %}
+
+<!-- Muut -->
+{% if site.theme_settings.muut_community_name %}
+<div class="comments">
+  {% include muut.html %}
+</div>
+{% endif %}


### PR DESCRIPTION
[Muut](https://muut.com) is commenting system similar to Disqus. Muut's features do distinguish it from Disqus, and Muut's business model does not depend on advertisements or ad-related data harvesting.