### PR TITLE
Fix feed title and description

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -4,10 +4,10 @@ layout: null
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>{{ site.theme.title | xml_escape }}</title>
+    <title>{{ site.theme_settings.title | xml_escape }}</title>
     <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
     <link>{{ site.url }}{{ site.baseurl }}/</link>
-    <description>{{ site.theme.description | xml_escape }}</description>
+    <description>{{ site.theme_settings.description | xml_escape }}</description>
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     {% for post in site.posts limit:15 %}
       <item>


### PR DESCRIPTION
`title` and `description` of feed were not present in the built Jekyll site due to being present as `site.theme.title` instead of `site.theme_settings.title`