### PR TITLE
Fix image for non-empty baseurl

### DIFF
--- a/_posts/2014-11-28-markdown-and-html.md
+++ b/_posts/2014-11-28-markdown-and-html.md
@@ -14,7 +14,7 @@ Content Cell  | Content Cell
 
 Here's an example of an image, which is included using Markdown:
 
-![Geometric pattern with fading gradient](/img/sample_feature_img_2.png)
+![Geometric pattern with fading gradient]({{ site.baseurl }}/img/sample_feature_img_2.png)
 
 Highlighting for code in Jekyll is done using Pygments or Rouge. This theme makes use of Rouge by default.
 


### PR DESCRIPTION
If `site.baseurl` is non-empty, then this link breaks