### PR TITLE
Use relative_url instead of prepend baseurl filter

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,5 @@
 {% if site.theme_settings.katex %}
-<script src="{{ "/assets/js/katex_init.js" | prepend: site.baseurl }}"></script>
+<script src="{{ "/assets/js/katex_init.js" | relative_url }}"></script>
 {% endif %}
 
 {% if site.theme_settings.footer_text %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,16 +5,16 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<!-- CSS -->
-	<link rel="stylesheet" href="{{ "/assets/css/main.css" | prepend: site.baseurl }}">
+	<link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url }}">
 
 	<!--Favicon-->
 	<link rel="shortcut icon" href="{{ site.baseurl }}/{{ site.theme_settings.favicon }}" type="image/x-icon">
 
 	<!-- Canonical -->
-	<link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+	<link rel="canonical" href="{{ page.url | replace:'index.html','' | relative_url }}">
 
 	<!-- RSS -->
-	<link rel="alternate" type="application/atom+xml" title="{{ site.theme_settings.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
+	<link rel="alternate" type="application/atom+xml" title="{{ site.theme_settings.title }}" href="{{ "/feed.xml" | relative_url }}" />
 
 	<!-- Font Awesome -->
 	<link href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,7 +18,7 @@
 			{% for page in site.pages %}
 			{% if page.title and page.hide != true %}
 			<li>
-				<a class="page-link" href="{{ page.url | prepend: site.baseurl }}">
+				<a class="page-link" href="{{ page.url | relative_url }}">
 					{{ page.title }}
 				</a>
 			</li>

--- a/_includes/icons.html
+++ b/_includes/icons.html
@@ -1,6 +1,6 @@
 {% if site.theme_settings.rss %}
 <li>
-	<a href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" title="{{ site.theme_settings.str_rss_follow }}">
+	<a href="{{ "/feed.xml" | relative_url }}" title="{{ site.theme_settings.str_rss_follow }}">
 		<i class="fa fa-fw fa-rss"></i>
 	</a>
 </li>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -15,7 +15,7 @@ layout: default
     <div class="post-teaser">
       <header>
         <h1>
-          <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">
+          <a class="post-link" href="{{ post.url | relative_url }}">
             {{ post.title }}
           </a>
         </h1>
@@ -25,7 +25,7 @@ layout: default
       </header>
       <div class="excerpt">
         {{ post.excerpt }}
-        <a class="button" href="{{ post.url | prepend: site.baseurl }}">
+        <a class="button" href="{{ post.url | relative_url }}">
           {{ site.theme_settings.str_continue_reading }}
         </a>
       </div>
@@ -36,13 +36,13 @@ layout: default
   {% if paginator.total_pages > 1 %}
   <div class="pagination">
     {% if paginator.previous_page %}
-    <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="button" >
+    <a href="{{ paginator.previous_page_path | relative_url | replace: '//', '/' }}" class="button" >
       <i class="fa fa-chevron-left"></i>
       {{ site.theme_settings.str_previous_page }}
     </a>
     {% endif %}
     {% if paginator.next_page %}
-    <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="button" >
+    <a href="{{ paginator.next_page_path | relative_url | replace: '//', '/' }}" class="button" >
       {{ site.theme_settings.str_next_page }}
       <i class="fa fa-chevron-right"></i>
     </a>

--- a/feed.xml
+++ b/feed.xml
@@ -5,15 +5,15 @@ layout: null
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ site.theme_settings.title | xml_escape }}</title>
-    <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+    <atom:link href="{{ "/feed.xml" | relative_url }}" rel="self" type="application/rss+xml"/>
     <link>{{ site.url }}{{ site.baseurl }}/</link>
     <description>{{ site.theme_settings.description | xml_escape }}</description>
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     {% for post in site.posts limit:15 %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
-        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+        <link>{{ post.url | relative_url }}</link>
+        <guid isPermaLink="true">{{ post.url | relative_url }}</guid>
         <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
       </item>

--- a/tags.html
+++ b/tags.html
@@ -19,7 +19,7 @@ hide: true
       {% if post.title != null %}
         <div class="tagged-post">
           <h3 class="title">
-            <a href="{{ post.url | prepend: site.baseurl }}">
+            <a href="{{ post.url | relative_url }}">
               {{ post.title }}
             </a>
           </h3>


### PR DESCRIPTION
Jekyll 3.3 ships with `relative_url` filter, Which will ensure `baseurl` is
prepended to anything passed to it. 

I've verified most links are working, Please let me know if anything is broken.

**Reference**:
- https://jekyllrb.com/news/2016/10/06/jekyll-3-3-is-here/#2-relative_url-and-absolute_url-filters
