### PR TITLE
Enable katex for single/all posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Mozilla's [ColorPicker](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Col
 Please refer to the [Jekyll docs for writing posts](https://jekyllrb.com/docs/posts/). Non-standard features are documented below.
 
 ### Math typesetting
-Wrap math expressions with `$$` signs in your posts and make sure you have set the `katex` variable in `_config.yml` to `true` for math typesetting.
+Wrap math expressions with `$$` signs in your posts and make sure you have set the `katex` variable in `_config.yml` to `true` if you want math typesetting in all pages or use `katex: true` in post frontmatter.
 
 For inline math typesetting, type your math expression on the *same line* as your content. For example:
 

--- a/_config.yml
+++ b/_config.yml
@@ -46,7 +46,7 @@ theme_settings:
   # Scripts
   google_analytics: # Tracking ID, e.g. "UA-000000-01"
   disqus_shortname:
-  katex: true # Enable if using math markup
+  katex: # Enable if using math markup in whole site
 
   # Localization strings
   str_follow_on: "Follow on"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -25,7 +25,7 @@
 	{% endif %}
 
 	<!-- KaTeX -->
-	{% if site.theme_settings.katex %}
+	{% if site.theme_settings.katex or page.katex %}
 	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.8.3/katex.min.css">
 	<script src="//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.8.3/katex.min.js"></script>
 	{% endif %}

--- a/_posts/2014-11-28-markdown-and-html.md
+++ b/_posts/2014-11-28-markdown-and-html.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Markdown and HTML
+katex: true
 ---
 
 Jekyll supports the use of [Markdown](http://daringfireball.net/projects/markdown/syntax) with inline HTML tags which makes it easier to quickly write posts with Jekyll, without having to worry too much about text formatting. A sample of the formatting follows.


### PR DESCRIPTION
Not all posts require math typesetting. User could enable katex per pages by setting `katex: true` in post front matter. Reducing load for pages without any math contents.

Changes are backward compatible, User will be able to use old settings. 