### PR TITLE
fix: closing h2 with h3

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -4,7 +4,7 @@ layout: default
 <article {% if page.feature-img %}class="feature-image"{% endif %}>
   <header style="background-image: url('{{ site.baseurl }}/{{ page.feature-img }}')">
     <h1 class="title">{{ page.title }}</h1>
-    {% if page.subtitle %}<h2 class="subtitle">{{ page.subtitle }}</h3>{% endif %}
+    {% if page.subtitle %}<h2 class="subtitle">{{ page.subtitle }}</h2>{% endif %}
   </header>
   <section class="post-content">{{ content }}</section>
 </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,7 @@ layout: default
 <article {% if page.feature-img %}class="feature-image"{% endif %}>
   <header style="background-image: url('{{ site.baseurl }}/{{ page.feature-img }}')">
     <h1 class="title">{{ page.title }}</h1>
-    {% if page.subtitle %}<h2 class="subtitle">{{ page.subtitle }}</h3>{% endif %}
+    {% if page.subtitle %}<h2 class="subtitle">{{ page.subtitle }}</h2>{% endif %}
     <p class="meta">
       {{ page.date | date: "%B %-d, %Y" }}
       {% if page.author %} - {{ page.author }}{% endif %}


### PR DESCRIPTION
Hey! 

Just noticed that the h2 tags in the page layouts are closed with h3 tags. Renders correctly anyway, but gets correctly flagged as an error by most inspection tools.

Best regards,
Kilian