### PR TITLE
Color for header description anchor element

### DIFF
--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -34,3 +34,4 @@ $feature-image-size: cover; // options include "cover", "contain", "auto"
 // Header description box
 $header-desc-background-color: #1ABC9C;
 $header-desc-text-color: #FFF;
+$header-desc-link-color: #02453D;

--- a/_sass/layouts/_index.scss
+++ b/_sass/layouts/_index.scss
@@ -12,6 +12,9 @@
 .call-out p:last-child {
   margin-bottom: 0;
 }
+.call-out a {
+  color: $header-desc-link-color
+}
 // Post listing
 .posts {
   .post-teaser {


### PR DESCRIPTION
Hi, love the theme! Hope you'll consider my PR (or a similar one with a different colour; I must stress that I'm no designer). Merry Christmas! 🎄 

Before:
<img width="1148" alt="screen shot 2017-12-24 at 22 49 29" src="https://user-images.githubusercontent.com/4622378/34329553-bdbe5b72-e8fc-11e7-9a22-9314ece26a2f.png">

After:
<img width="992" alt="screen shot 2017-12-24 at 22 43 57" src="https://user-images.githubusercontent.com/4622378/34329547-989d7d96-e8fc-11e7-9a4b-3c9970fd62e6.png">

Currently links in the header description are the same colour as the background. Here I've darkened the header description background colour (which is the link colour everywhere else in the theme) to the point at which it meets the [WCAG AAA requirements](https://webaim.org/resources/contrastchecker/) for contrast ratio in large text:

<img width="772" alt="screen shot 2017-12-24 at 22 51 30" src="https://user-images.githubusercontent.com/4622378/34329563-212939de-e8fd-11e7-9901-4eb8737b9285.png">

