### PR TITLE
add 'jekyll-theme-type' to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 gem 'rouge'
 gem 'jekyll'
 gem 'jekyll-paginate'
+gem 'jekyll-theme-type'


### PR DESCRIPTION
currently the theme doesnt work on the gh-pages branch unless you add `jekyll-theme-type` gem to the gemfile, or install manually, as expected. 