### PR TITLE
KaTeX updates and optimizations

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-{% if site.theme_settings.katex %}
+{% if site.theme_settings.katex and page.id %}
 <script src="{{ "/assets/js/katex_init.js" | relative_url }}"></script>
 {% endif %}
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -25,9 +25,9 @@
 	{% endif %}
 
 	<!-- KaTeX -->
-	{% if site.theme_settings.katex %}
-	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.8.3/katex.min.css">
-	<script src="//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.8.3/katex.min.js"></script>
+	{% if site.theme_settings.katex and page.id %}
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0-alpha/dist/katex.min.css" integrity="sha384-BTL0nVi8DnMrNdMQZG1Ww6yasK9ZGnUxL1ZWukXQ7fygA1py52yPp9W4wrR00VML" crossorigin="anonymous">
+	<script src="https://cdn.jsdelivr.net/npm/katex@0.10.0-alpha/dist/katex.min.js" integrity="sha384-y6SGsNt7yZECc4Pf86XmQhC4hG2wxL6Upkt9N1efhFxfh6wlxBH0mJiTE8XYclC1" crossorigin="anonymous"></script>
 	{% endif %}
 
 	<!-- Google Analytics -->

--- a/assets/js/katex_init.js
+++ b/assets/js/katex_init.js
@@ -16,11 +16,12 @@ Array.prototype.forEach.call(elements, function(element) {
      if (element.type.indexOf('mode=display') != -1){
        katexElement.className += "math-display";
        textToRender = '\\displaystyle {' + textToRender + '}';
+       katex.render(textToRender, katexElement, {displayMode: true});
      } else {
        katexElement.className += "math-inline";
+       katex.render(textToRender, katexElement);
      }
 
-     katex.render(textToRender, katexElement);
      element.parentNode.insertBefore(katexElement, element);
   }
 });


### PR DESCRIPTION
1. KaTeX is included under **head.html** and initialized under **footer.html**, which means it is loaded for every Jekyll page. Since it is only necessary to load KaTeX for blog posts, I made some changes to the files by adding page.id as an additional condition to the liquid tags.

2. The theme currently renders math, under _display mode_, without including **displayMode** as an argument to **katex.render**. This results to math being displayed at the left-side of the post, whereas it should be displayed at the center. I updated the render arguments for display mode under **katex_init.js**. Here's a demo for this: https://saojeda.tech/normal-equation-derivation

3. I updated the KaTeX version to **0.10.0-alpha**. It is tagged as pre-release, but it is already recommended for usage as per instruction in the KaTeX repository's README

These changes are personally tested on my Jekyll website with Type theme installed.