### PR TITLE
Allow variables overrides + Add README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,48 @@ $font-family-headings: 'Playfair Display', Helvetica, Arial, sans-serif;
 
 Mozilla's [ColorPicker](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Colors/Color_picker_tool) is a helpful tool to get your preferred colours in hexadecimal or RGBA form for use in `_variables.scss`.
 
+### Customize style when using the remote_theme
+
+If you're using Type Theme as a `remote_theme`, you can override variables and styles.
+To do so, simply create a `assets/css/main.scss` file on your website with the following content:
+
+```scss
+// assets/css/main.scss
+---
+---
+
+@import "type-theme";
+```
+
+`@import "type-theme";` is including the theme styles, so you can add custom imports before and after it, depending on your needs.
+Best practice is to put your custom files in the `_sass` folder of your progect. Jekyll will automatically look for them there.
+For example, say you wanted to override some theme variables and add some custom styles, you can create the following files:
+
+```scss
+// _sass/_variables.scss
+$background-color: black;
+```
+
+```sass
+// _sass/_custom.sass
+
+// SASS is supported as well, just note the file extension is .sass
+.feature-image header
+  height: 300px
+```
+
+Then import them both into `main.scss`:
+
+```scss
+// assets/css/main.scss
+---
+---
+
+@import "variables";
+@import "type-theme";
+@import "custom";
+```
+
 ## Posts and pages in Type Theme
 Please refer to the [Jekyll docs for writing posts](https://jekyllrb.com/docs/posts/). Non-standard features are documented below.
 

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -1,37 +1,37 @@
 // Typography
-$font-family-main: 'Source Sans Pro', Helvetica, Arial, sans-serif;
-$font-family-headings: 'Source Sans Pro', Helvetica, Arial, sans-serif;
-$font-size: 1.25em;
+$font-family-main: 'Source Sans Pro', Helvetica, Arial, sans-serif !default;
+$font-family-headings: 'Source Sans Pro', Helvetica, Arial, sans-serif !default;
+$font-size: 1.25em !default;
 
 // Padding
-$padding-large: 20%;
-$padding-small: 5%;
-$padding-x-small: 3%;
+$padding-large: 20% !default;
+$padding-small: 5% !default;
+$padding-x-small: 3% !default;
 
 // Brand colours
-$brand-color: #fff;
-$background-color: #fff;
-$border-color: rgba(0, 0, 0, 0.1); // rgba recommended if using feature images
+$brand-color: #fff !default;
+$background-color: #fff !default;
+$border-color: rgba(0, 0, 0, 0.1) !default; // rgba recommended if using feature images
 
 // Typography colours
-$text-color: #383838;
-$link-color: #1ABC9C;
-$selection-color: #D4D4D4; // visible when highlighting text
+$text-color: #383838 !default;
+$link-color: #1ABC9C !default;
+$selection-color: #D4D4D4 !default; // visible when highlighting text
 
 // Tags color
-$tags-color: #b0b0b0;
+$tags-color: #b0b0b0 !default;
 
 //Search color
-$search-color: #999;
+$search-color: #999 !default;
 
 // Header colours
-$header-link-color: #383838;
+$header-link-color: #383838 !default;
 
 // Feature image for articles
-$feature-image-text-color: #fff;
-$feature-image-size: cover; // options include "cover", "contain", "auto"
+$feature-image-text-color: #fff !default;
+$feature-image-size: cover !default; // options include "cover", "contain", "auto"
 
 // Header description box
-$header-desc-background-color: #1ABC9C;
-$header-desc-text-color: #FFF;
-$header-desc-link-color: #02453D;
+$header-desc-background-color: #1ABC9C !default;
+$header-desc-text-color: #FFF !default;
+$header-desc-link-color: #02453D !default;


### PR DESCRIPTION
## Description
* Marks all variables as `!default` to allow overriding.
* Updates README to explain how to override styles.

Probably Fixes last point in #59 