### PR TITLE
Feature title

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ feature-img: "assets/img/sample_feature_img.png"
 ---
 ```
 
+By default, the page title will be displayed on top of the feauture image.
+You can change it to something else by specifying the feature-title
+
 ### Hiding pages from navigation
 
 In the Front Matter of a page, add `hide: true` to prevent the page from showing up in the header's navigation bar (visitors can still visit the URL through other means).

--- a/README.md
+++ b/README.md
@@ -208,8 +208,17 @@ feature-img: "assets/img/sample_feature_img.png"
 ---
 ```
 
-By default, the page title will be displayed on top of the feauture image.
-You can change it to something else by specifying the feature-title
+By default, the page title will be displayed on top of the feature image and on the browser tab.
+You can change the title displayed on the feature image to something else by specifying the feature-title in the [front matter](http://jekyllrb.com/docs/frontmatter/):
+
+```yml
+---
+layout: post
+title: Short title
+feature-title: A much longer title
+feature-img: "assets/img/sample_feature_img.png"
+---
+```
 
 ### Hiding pages from navigation
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,7 @@ layout: default
 ---
 <article {% if page.feature-img %}class="feature-image"{% endif %}>
   <header style="background-image: url('{{ site.baseurl }}/{{ page.feature-img }}')">
-    <h1 class="title">{{ page.title }}</h1>
+    <h1 class="title">{{ page.feature-title | default: page.title }}</h1>
     {% if page.subtitle %}<h2 class="subtitle">{{ page.subtitle }}</h2>{% endif %}
   </header>
   <section class="post-content">{{ content }}</section>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,7 +3,7 @@ layout: default
 ---
 <article {% if page.feature-img %}class="feature-image"{% endif %}>
   <header style="background-image: url('{{ site.baseurl }}/{{ page.feature-img }}')">
-    <h1 class="title">{{ page.title }}</h1>
+    <h1 class="title">{{ page.feature-title | default: page.title }}</h1>
     {% if page.subtitle %}<h2 class="subtitle">{{ page.subtitle }}</h2>{% endif %}
     <p class="meta">
       {{ page.date | date: "%B %-d, %Y" }}


### PR DESCRIPTION
By default, a page/post title will be displayed on top of the feature image AND on the browser tab.
I actually find myself in the situation where I wanted the two to differ, so I thought to provide this as a feature. `title` will still be used as default, so this change is fully backwards-compatible.