### PR TITLE
Sort site nav

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,7 +15,7 @@
 	</div>
 	<nav class="site-nav">
 		<ul>
-			{% for page in site.pages %}
+			{% for page in site.pages | sort: site.theme_settings.site_navigation_sort %}
 			{% if page.title and page.hide != true %}
 			<li>
 				<a class="page-link" href="{{ page.url | relative_url }}">
@@ -26,7 +26,7 @@
 			{% endfor %}
 			<!-- Social icons from Font Awesome, if enabled  -->
 			{% include icons.html %}
-            
+
             <!-- Search bar -->
             {% if site.theme_settings.search %}
             <li>
@@ -40,5 +40,5 @@
             {% endif %}
 		</ul>
 	</nav>
-    
+
 </header>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,6 @@
 		</h1>
 	</div>
 	<nav class="site-nav">
-		<!-- lostisland test -->
 		<ul>
 			{% assign site_pages = site.pages | sort: site.theme_settings.site_navigation_sort %}
 			{% for page in site_pages %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,8 +14,10 @@
 		</h1>
 	</div>
 	<nav class="site-nav">
+		<!-- lostisland test -->
 		<ul>
-			{% for page in site.pages | sort: site.theme_settings.site_navigation_sort %}
+			{% assign site_pages = site.pages | sort: site.theme_settings.site_navigation_sort %}
+			{% for page in site_pages %}
 			{% if page.title and page.hide != true %}
 			<li>
 				<a class="page-link" href="{{ page.url | relative_url }}">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,7 +15,11 @@
 	</div>
 	<nav class="site-nav">
 		<ul>
-			{% assign site_pages = site.pages | sort: site.theme_settings.site_navigation_sort %}
+			{% if site.theme_settings.site_navigation_sort %}
+				{% assign site_pages = site.pages | sort: site.theme_settings.site_navigation_sort %}
+			{% else %}
+				{% assign site_pages = site.pages %}
+			{% endif %}
 			{% for page in site_pages %}
 			{% if page.title and page.hide != true %}
 			<li>


### PR DESCRIPTION
This PR adds the ability to sort the pages as they're listed in the site nav section. 

1. Set `site_navigation_sort` in theme settings to something like `'order'`
2. Add `order: n` to the yaml frontmatter of any non-hidden pages for the site nav.
    ```yaml
    layout: page
    title: Team
    permalink: /team/
    order: 4
    ```

This seems like a bit of a hack, but my jekyll and liquid knowledge is fairly limited. Open to suggestions!

Protip: Probably want to do a squash merge on this one.