### PR TITLE
FIX: link error in search page

### DIFF
--- a/search.html
+++ b/search.html
@@ -22,7 +22,7 @@ hide: true
         "author": "{{ post.author | xml_escape }}",
         "category": "{{ post.category | xml_escape }}",
         "content": {{ post.content | strip_html | strip_newlines | jsonify }},
-        "url": "{{ site.baseurl }}/{{ post.url | xml_escape }}"
+        "url": "{{ site.baseurl }}{{ post.url | xml_escape }}"
       }
       {% unless forloop.last %},{% endunless %}
     {% endfor %}


### PR DESCRIPTION
Hi, me again !

I fix an auto-generated link in the search page on my blog.
(At first, I thought the error is emitted because I made a few changes to customize the blog.)

But today, fixing this issue, I think the auto-generated link should be changed like this commits.

Before changing, the code made two `/` in links.
For instance, `//study/...`. According to the master branch of this repo, the link seems like `/type-theme//2014/...`.

Please tell me if I made mistakes. Thx.